### PR TITLE
#161172050 Add Missing Search Option to Admin and Attendant Product Pages

### DIFF
--- a/ui/products-admin.html
+++ b/ui/products-admin.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>StoreManager - Home</title>
+    <title>StoreManager - Products</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/style.css">
@@ -13,15 +13,21 @@
     <div class="nav-logo"><img src="images/shopping-list.png"></div>
     <div class="nav-logo-text">STORE MANAGER</div>
     <div class="nav-menu">
-        <button type="submit">PROFILE</button>
         <button type="submit">LOG OUT</button>
     </div>
 </div>
-
 <!--# MAIN SECTION-->
 <div class="main-section">
     <div class="products-section">
         <div class="dash-header">Products</div>
+        <div class="search-bar-section">
+            <div class="my-search-input">
+                <input type="text" placeholder="Search For Product By Name..">
+            </div>
+            <div>
+                <button type="submit" class="my-search-button">Search</button>
+            </div>
+        </div>
         <div class="all-products-section">
             <div class="product-item">
                 <div class="product-image"><img src="images/shopping.png"></div>

--- a/ui/products.html
+++ b/ui/products.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>StoreManager - Home</title>
+    <title>StoreManager - Products</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/style.css">
@@ -13,8 +13,6 @@
     <div class="nav-logo"><img src="images/shopping-list.png"></div>
     <div class="nav-logo-text">STORE MANAGER</div>
     <div class="nav-menu">
-        <!--<div class="nav-menu-item">Profile</div>-->
-        <!--<div class="nav-menu-item">Records</div>-->
         <button type="submit">PROFILE</button>
         <button type="submit">LOG OUT</button>
     </div>
@@ -24,6 +22,14 @@
 <div class="main-section">
     <div class="products-section">
         <div class="dash-header">Products</div>
+        <div class="search-bar-section">
+            <div class="my-search-input">
+                <input type="text" placeholder="Search For Product By Name..">
+            </div>
+            <div>
+                <button type="submit" class="my-search-button">Search</button>
+            </div>
+        </div>
         <div class="all-products-section">
             <div class="product-item">
                 <div class="product-image"><img src="images/shopping.png"></div>


### PR DESCRIPTION
#### What does this PR do?
Add Search option on the Product pages of both the Admin and Attendant
#### Description of Task to be completed?
None
#### How should this be manually tested?
1. `git clone https://github.com/johnwayodi/store-manager.git`
2. Ensure you are in the directory where you cloned this repository, **_store-manager_** by default
3. `git checkout bg-search-products-161172050`
4. open **_products.html_**, **_products-admin_** on browser
#### Any background context you want to provide?
This is a correction made to the initial pages which failed to capture this feature which manifested to a bug 
#### What are the relevant pivotal tracker stories?
#161172050
#### Screenshots
_**products view for Store Attendant**_
![products](https://user-images.githubusercontent.com/10683903/46850125-400ed780-cdfb-11e8-938a-2a89ebb9f527.png)
_**products view for Store Admin**_
![products-admin](https://user-images.githubusercontent.com/10683903/46850148-5fa60000-cdfb-11e8-95d1-f7b93b465cc3.png)
